### PR TITLE
Add events manager UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # worship-team-planner
-A simple planner web app for a worship team and discipleship hub, providing features similar to Planning Center Services such as schedule management, service planning, and resources for team members.
+A simple planner web app for a worship team and discipleship hub.
+
+## Features
+
+- **Rehearsal Schedule** – track upcoming rehearsal dates and notes. Entries are stored in your browser's `localStorage` so they persist across page reloads.
+- **Event & Setlist Manager** – create events, build setlists for each event and attach song PDFs or YouTube links.
+- **Resource Links** – quick access to free online worship and discipleship material.
+
+## Usage
+
+1. Clone or download this repository.
+2. Open `index.html` in your browser – no server is required.
+3. Use the **Schedule** form to add rehearsal dates and notes.
+4. In the **Events** section, create events and setlists, then upload song PDFs (stored locally in your browser) and optional YouTube links.
+
+All data is saved to your browser only by default. Clearing browser data will remove your schedule, events and songs.
+
+## Optional Online Storage
+
+You can sync data to a free [Firebase](https://firebase.google.com/) project:
+
+1. Create a Firebase project and enable **Firestore** in test mode.
+2. Copy the project's configuration snippet and replace the placeholders in `script.js` (`firebaseConfig` object).
+3. Reload the page. If Firebase credentials are present, data will be saved to Firestore instead of `localStorage`.
+
+The Firebase Spark plan has generous limits that should be enough for small teams. Be sure to secure your Firestore rules before going to production.

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Worship Team &amp; Discipleship</title>
     <link rel="stylesheet" href="style.css">
+    <!-- Optional: Load Firebase for online storage -->
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
     <script defer src="script.js"></script>
 </head>
 <body>
@@ -15,6 +18,7 @@
                 <li><a href="#home">Home</a></li>
                 <li><a href="#teachings">Teachings</a></li>
                 <li><a href="#schedule">Schedule</a></li>
+                <li><a href="#events">Events</a></li>
                 <li><a href="#resources">Resources</a></li>
             </ul>
         </nav>
@@ -65,6 +69,40 @@
                 <button type="submit">Add to Schedule</button>
             </form>
             <ul id="schedule-list"></ul>
+        </section>
+
+        <!-- Events & Setlists Section -->
+        <section id="events">
+            <h2>Event &amp; Setlist Manager</h2>
+            <div id="event-manager">
+                <h3>Add Event</h3>
+                <form id="event-form">
+                    <input type="text" id="event-name" placeholder="Event name" required>
+                    <input type="date" id="event-date" required>
+                    <button type="submit">Add Event</button>
+                </form>
+                <ul id="event-list"></ul>
+            </div>
+
+            <div id="setlist-manager" style="display: none;">
+                <h3>Setlists for <span id="current-event-name"></span></h3>
+                <form id="setlist-form">
+                    <input type="text" id="setlist-name" placeholder="Setlist name" required>
+                    <button type="submit">Add Setlist</button>
+                </form>
+                <ul id="setlist-list"></ul>
+            </div>
+
+            <div id="song-manager" style="display: none;">
+                <h3>Songs for <span id="current-setlist-name"></span></h3>
+                <form id="song-form">
+                    <input type="text" id="song-title" placeholder="Song title" required>
+                    <input type="file" id="song-pdf" accept="application/pdf" required>
+                    <input type="url" id="song-youtube" placeholder="YouTube link">
+                    <button type="submit">Add Song</button>
+                </form>
+                <ul id="song-list"></ul>
+            </div>
         </section>
 
         <!-- Resources Section -->


### PR DESCRIPTION
## Summary
- add missing Events section to the page so event & setlist code works
- link Events section from the navbar
- expand README with usage instructions
- add optional Firebase sync

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883c099688c83239dcaab05a1ba7835